### PR TITLE
Add German BOStrab signal G4 60

### DIFF
--- a/DE/BOStrab/G4_60_Tafel.svg
+++ b/DE/BOStrab/G4_60_Tafel.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   width="156.77524"
+   height="230.75842"
+   id="svg2">
+  <defs
+     id="defs4" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="layer1"
+     style="display:inline" />
+  <g
+     transform="translate(42.927212,104.99011)"
+     id="layer5"
+     style="display:inline">
+    <rect
+       width="150.53589"
+       height="222.38737"
+       x="-39.479004"
+       y="-101.13312"
+       id="rect4663"
+       style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:8.47999954;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
+    <path
+       d="m 39.774763,67.458771 a 21.140112,15.332388 0 0 1 -1.19e-4,0.05143"
+       id="path4238"
+       style="fill:#000000;fill-opacity:1;stroke:none" />
+    <path
+       d="m 34.429108,-58.532737 c -17.754634,0.0014 -35.4867274,15.895681 -35.4867274,31.049818 l 0,81.517098 c 0,10.237997 10.6292153,26.433084 34.8463664,26.433084 19.637375,0 34.872914,-15.094117 34.872914,-26.433084 l 0,-38.767016 c 0,-27.432993 -34.160406,-28.078946 -46.159309,-24.1473467 l 0,-20.4811123 c 0,-10.973199 26.308137,-10.607423 26.308137,0 l 21.131892,0 c 0,-13.280837 -17.758815,-29.173063 -35.513273,-29.171441 z M 33.121662,9.7904475 c 6.05115,-0.2383903 12.48703,2.4084885 12.48703,7.7398225 l 0,31.547705 c 0,13.884336 -22.866248,14.764898 -22.866248,0 l 0,-31.819278 c 0,-4.811985 5.039979,-7.257907 10.379218,-7.4682495 z"
+       id="path4637"
+       style="color:#000000;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate" />
+  </g>
+</svg>


### PR DESCRIPTION
This signal was missing, but there are a few of them in Karlsruhe. I used the same font as for the EBO speed signals.
